### PR TITLE
fixing CONFIG.localDev true or false issue

### DIFF
--- a/copado-function/app/Commit.js
+++ b/copado-function/app/Commit.js
@@ -40,6 +40,7 @@ const CONFIG = {
     configFilePath: '.mcdevrc.json',
     credentialName: process.env.credentialName,
     debug: process.env.debug === 'false' ? false : true,
+    localDev: process.env.LOCAL_DEV === 'false' ? false : true,
     envId: process.env.envId,
     enterpriseId: process.env.enterprise_id,
     mainBranch: process.env.main_branch,
@@ -248,7 +249,7 @@ class Log {
      */
     static error(msg) {
         Log.warn('❌  ' + msg);
-        execSync(`copado --error-message "${msg}"`);
+        execSync(`copado --error-message "${msg.replace(/"/g,'\"')}"`);
     }
     /**
      * @param {string} msg your log message
@@ -256,7 +257,7 @@ class Log {
      */
     static progress(msg) {
         Log.debug(msg);
-        execSync(`copado --progress "${msg}"`);
+        execSync(`copado --progress "${msg.replace(/"/g,'\"')}"`);
     }
     /**
      * used to overcome bad timestmaps created by copado that seem to be created asynchronously
@@ -369,7 +370,7 @@ class Util {
             Util.execCommand('Initializing npm', ['npm init -y'], 'Completed initializing NPM');
         }
         let installer;
-        if (process.env.LOCAL_DEV) {
+        if (CONFIG.localDev) {
             installer = CONFIG.mcdevVersion;
         } else if (CONFIG.mcdevVersion.charAt(0) === '#') {
             // assume branch of mcdev's git repo shall be loaded
@@ -662,7 +663,7 @@ class Commit {
      * @returns {void}
      */
     static addSelectedComponents(gitAddArr) {
-        if (process.env.LOCAL_DEV) {
+        if (CONFIG.localDev) {
             Log.debug('🔥 Skipping git action in local dev environment');
             return;
         }
@@ -696,11 +697,11 @@ class Commit {
         const stdout = execSync('git diff --staged --name-only');
         Log.debug('Git diff ended with the result: >' + stdout + '<');
         if (stdout && 0 < stdout.length) {
-            if (process.env.LOCAL_DEV) {
+            if (CONFIG.localDev) {
                 Log.debug('🔥 Skipping git action in local dev environment');
                 return;
             }
-
+            
             Util.execCommand(
                 'Commit',
                 ['git commit -m "' + CONFIG.commitMessage + '"'],

--- a/copado-function/app/Deploy.js
+++ b/copado-function/app/Deploy.js
@@ -29,6 +29,7 @@ const CONFIG = {
     configFilePath: '.mcdevrc.json',
     credentialName: process.env.credentialName,
     debug: process.env.debug === 'false' ? false : true,
+    localDev: process.env.LOCAL_DEV === 'false' ? false : true,
     envId: process.env.envId,
     enterpriseId: process.env.enterprise_id,
     mainBranch: process.env.main_branch,
@@ -256,7 +257,7 @@ class Log {
      */
     static error(msg) {
         Log.warn('❌  ' + msg);
-        execSync(`copado --error-message "${msg}"`);
+        execSync(`copado --error-message "${msg.replace(/"/g,'\"')}"`);
     }
     /**
      * @param {string} msg your log message
@@ -264,7 +265,7 @@ class Log {
      */
     static progress(msg) {
         Log.debug(msg);
-        execSync(`copado --progress "${msg}"`);
+        execSync(`copado --progress "${msg.replace(/"/g,'\"')}"`);
     }
     /**
      * used to overcome bad timestmaps created by copado that seem to be created asynchronously
@@ -377,7 +378,7 @@ class Util {
             Util.execCommand('Initializing npm', ['npm init -y'], 'Completed initializing NPM');
         }
         let installer;
-        if (process.env.LOCAL_DEV) {
+        if (CONFIG.localDev) {
             installer = CONFIG.mcdevVersion;
         } else if (CONFIG.mcdevVersion.charAt(0) === '#') {
             // assume branch of mcdev's git repo shall be loaded
@@ -762,7 +763,7 @@ class Deploy {
      * @returns {void}
      */
     static merge(fromCommit) {
-        if (process.env.LOCAL_DEV) {
+        if (CONFIG.localDev) {
             Log.debug('🔥 Skipping git action in local dev environment');
             return;
         }
@@ -780,7 +781,7 @@ class Deploy {
      * @returns {void}
      */
     static push(toBranch) {
-        if (process.env.LOCAL_DEV) {
+        if (CONFIG.localDev) {
             Log.debug('🔥 Skipping git action in local dev environment');
             return;
         }
@@ -798,7 +799,7 @@ class Deploy {
      * @returns {void}
      */
     static promote(toBranch) {
-        if (process.env.LOCAL_DEV) {
+        if (CONFIG.localDev) {
             Log.debug('🔥 Skipping git action in local dev environment');
             return;
         }

--- a/copado-function/app/Retrieve.js
+++ b/copado-function/app/Retrieve.js
@@ -31,6 +31,7 @@ const CONFIG = {
     configFilePath: '.mcdevrc.json',
     credentialName: process.env.credentialName,
     debug: process.env.debug === 'false' ? false : true,
+    localDev: process.env.LOCAL_DEV === 'false' ? false : true,
     envId: process.env.envId,
     enterpriseId: process.env.enterprise_id,
     mainBranch: process.env.main_branch,
@@ -338,7 +339,7 @@ class Util {
             Util.execCommand('Initializing npm', ['npm init -y'], 'Completed initializing NPM');
         }
         let installer;
-        if (process.env.LOCAL_DEV) {
+        if (CONFIG.localDev) {
             installer = CONFIG.mcdevVersion;
         } else if (CONFIG.mcdevVersion.charAt(0) === '#') {
             // assume branch of mcdev's git repo shall be loaded

--- a/copado-function/app/Retrieve.js
+++ b/copado-function/app/Retrieve.js
@@ -218,7 +218,7 @@ class Log {
      */
     static error(msg) {
         Log.warn('❌  ' + msg);
-        execSync(`copado --error-message "${msg}"`);
+        execSync(`copado --error-message "${msg.replace(/"/g,'\"')}"`);
     }
     /**
      * @param {string} msg your log message
@@ -226,7 +226,7 @@ class Log {
      */
     static progress(msg) {
         Log.debug(msg);
-        execSync(`copado --progress "${msg}"`);
+        execSync(`copado --progress "${msg.replace(/"/g,'\"')}"`);
     }
     /**
      * used to overcome bad timestmaps created by copado that seem to be created asynchronously

--- a/copado-function/app/Upgrade.js
+++ b/copado-function/app/Upgrade.js
@@ -40,6 +40,7 @@ const CONFIG = {
     configFilePath: '.mcdevrc.json',
     credentialName: process.env.credentialName,
     debug: process.env.debug === 'false' ? false : true,
+    localDev: process.env.LOCAL_DEV === 'false' ? false : true,
     envId: null,
     enterpriseId: process.env.enterprise_id,
     mainBranch: process.env.main_branch,
@@ -338,7 +339,7 @@ class Util {
             Util.execCommand('Initializing npm', ['npm init -y'], 'Completed initializing NPM');
         }
         let installer;
-        if (process.env.LOCAL_DEV) {
+        if (CONFIG.localDev) {
             installer = CONFIG.mcdevVersion;
         } else if (CONFIG.mcdevVersion.charAt(0) === '#') {
             // assume branch of mcdev's git repo shall be loaded
@@ -586,7 +587,7 @@ class Upgrade {
      * @returns {void}
      */
     static gitAddConfig() {
-        if (process.env.LOCAL_DEV) {
+        if (CONFIG.localDev) {
             Log.debug('🔥 Skipping git action in local dev environment');
             return;
         }
@@ -629,7 +630,7 @@ class Upgrade {
         const stdout = execSync('git diff --staged --name-only');
         Log.debug('Git diff ended with the result: >' + stdout + '<');
         if (stdout && 0 < stdout.length) {
-            if (process.env.LOCAL_DEV) {
+            if (CONFIG.localDev) {
                 Log.debug('🔥 Skipping git action in local dev environment');
                 return;
             }

--- a/copado-function/app/Upgrade.js
+++ b/copado-function/app/Upgrade.js
@@ -218,7 +218,7 @@ class Log {
      */
     static error(msg) {
         Log.warn('❌  ' + msg);
-        execSync(`copado -e "${msg}"`);
+        execSync(`copado --error-message "${msg.replace(/"/g,'\"')}"`);
     }
     /**
      * @param {string} msg your log message
@@ -226,7 +226,7 @@ class Log {
      */
     static progress(msg) {
         Log.debug(msg);
-        execSync(`copado -p "${msg}"`);
+        execSync(`copado --progress "${msg.replace(/"/g,'\"')}"`);
     }
     /**
      * used to overcome bad timestmaps created by copado that seem to be created asynchronously


### PR DESCRIPTION
# PR details

## What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [X] Bug fix
- [ ] New metadata support
- [ ] Enhanced Copado function
- [ ] Add a GUI option
- [ ] Add something to the core
- [ ] Other, please explain:

## What changes did you make? (Give an overview)

Added:
localDev: process.env.LOCAL_DEV === 'false' ? false : true,
in every config, on Retrieve.js, Upgrade.js, Commit.js and Deploy.js

And changed every time it calls it from process.env.LOCAL_DEV to use the CONFIG.localDev that is getting created on the CONFIG variable.

Also added some changes to the Log.error and Log.progress of Commit.js, Deploy.js, Retrieve.js and Upgrade.js.