### PR TITLE
155 task commitjs should use logerror not logresult if it did not find anything to commit

### DIFF
--- a/copado-function/app/Commit.js
+++ b/copado-function/app/Commit.js
@@ -740,7 +740,7 @@ class Commit {
             }
             Log.result(gitDiffArr, 'Commit completed');
         } else {
-            Log.result(
+            Log.error(
                 'Nothing to commit as all selected components have the same content as already exists in Git.',
                 'Nothing to commit'
             );

--- a/copado-function/app/Commit.js
+++ b/copado-function/app/Commit.js
@@ -744,6 +744,7 @@ class Commit {
                 'Nothing to commit as all selected components have the same content as already exists in Git.',
                 'Nothing to commit'
             );
+            throw new Error('Nothing to commit');
         }
     }
 }


### PR DESCRIPTION
# PR details

## What is the purpose of this pull request? (put an "X" next to an item)

- [X] TASK

## What changes did you make? (Give an overview)

- Changed log.result to log.error if nothing to commit.
- Added a throw new Error() after.

Tested in local and in server environment, and it works:

![image](https://user-images.githubusercontent.com/72609808/195092637-9586a158-0ae8-4b24-979b-b072d62220d8.png)
