### PR TITLE
#34  error message hyperlink with jobid

### DIFF
--- a/force-app/main/default/lwc/marketingCloudCopadoDataTable/marketingCloudCopadoDataTable.js
+++ b/force-app/main/default/lwc/marketingCloudCopadoDataTable/marketingCloudCopadoDataTable.js
@@ -360,7 +360,6 @@ export default class MarketingCloudCopadoDataTable extends LightningElement {
                 messageData: [
                     {
                         url: JobUrl,
-                        //  url: "https://copadonull71743980.lightning.force.com",
                         label: "click here"
                     }
                 ]

--- a/force-app/main/default/lwc/marketingCloudCopadoDataTable/marketingCloudCopadoDataTable.js
+++ b/force-app/main/default/lwc/marketingCloudCopadoDataTable/marketingCloudCopadoDataTable.js
@@ -351,21 +351,17 @@ export default class MarketingCloudCopadoDataTable extends LightningElement {
             }
         } else if (jobExecution.copado__Status__c === "Error") {
             this.loadingState(false);
-            let JobUrl =
-                "https://copadonull71743980.lightning.force.com/lightning/r/copado__JobExecution__c/" +
-                jobExecutionId +
-                "/view";
+            let JobUrl = "/" +jobExecutionId;
             const errEvent = new ShowToastEvent({
                 title: "Error",
                 variant: "error",
                 mode: "sticky",
-                message: "Refreshing metadata list failed. For more details {0} please go to {1}",
+                message: "Refreshing metadata list failed. For more details {0}.",
                 messageData: [
-                    "Salesforce",
                     {
                         url: JobUrl,
                         //  url: "https://copadonull71743980.lightning.force.com",
-                        label: "this Job Execution record"
+                        label: "click here"
                     }
                 ]
             });

--- a/force-app/main/default/lwc/marketingCloudCopadoDataTable/marketingCloudCopadoDataTable.js
+++ b/force-app/main/default/lwc/marketingCloudCopadoDataTable/marketingCloudCopadoDataTable.js
@@ -351,12 +351,12 @@ export default class MarketingCloudCopadoDataTable extends LightningElement {
             }
         } else if (jobExecution.copado__Status__c === "Error") {
             this.loadingState(false);
-            let JobUrl = "/" +jobExecutionId;
+            let JobUrl = "/" + jobExecutionId;
             const errEvent = new ShowToastEvent({
                 title: "Error",
                 variant: "error",
                 mode: "sticky",
-                message: "Refreshing metadata list failed. For more details {0}.",
+                message: "Refreshing metadata list failed. For more details {0}.{1}",
                 messageData: [
                     {
                         url: JobUrl,

--- a/force-app/main/default/lwc/marketingCloudCopadoDataTable/marketingCloudCopadoDataTable.js
+++ b/force-app/main/default/lwc/marketingCloudCopadoDataTable/marketingCloudCopadoDataTable.js
@@ -356,7 +356,7 @@ export default class MarketingCloudCopadoDataTable extends LightningElement {
                 title: "Error",
                 variant: "error",
                 mode: "sticky",
-                message: "Refreshing metadata list failed. For more details {0}.{1}",
+                message: "Refreshing metadata list failed. For more details {0}.",
                 messageData: [
                     {
                         url: JobUrl,

--- a/force-app/main/default/lwc/marketingCloudCopadoDataTable/marketingCloudCopadoDataTable.js
+++ b/force-app/main/default/lwc/marketingCloudCopadoDataTable/marketingCloudCopadoDataTable.js
@@ -351,10 +351,25 @@ export default class MarketingCloudCopadoDataTable extends LightningElement {
             }
         } else if (jobExecution.copado__Status__c === "Error") {
             this.loadingState(false);
-            this.showError(
-                ` An error occurred while Metadata file Retrieve.please refere to the job id: `,
-                jobExecutionId
-            );
+            let JobUrl =
+                "https://copadonull71743980.lightning.force.com/lightning/r/copado__JobExecution__c/" +
+                jobExecutionId +
+                "/view";
+            const errEvent = new ShowToastEvent({
+                title: "Error",
+                variant: "error",
+                mode: "sticky",
+                message: "Refreshing metadata list failed. For more details {0} please go to {1}",
+                messageData: [
+                    "Salesforce",
+                    {
+                        url: JobUrl,
+                        //  url: "https://copadonull71743980.lightning.force.com",
+                        label: "this Job Execution record"
+                    }
+                ]
+            });
+            this.dispatchEvent(errEvent);
         } else {
             this.showError(
                 `Error while doing metadata retrieve: `,


### PR DESCRIPTION
# PR details

## What is the purpose of this pull request? (put an "X" next to an item)


- [ ] Bug fix
- Error message with job execution  Id. user click and navigate the error detail page. 
- [ ] Add a GUI option
- Error message with job execution Id. user click and navigate the error detail page. 

## What changes did you make? (Give an overview)

closes #34 

