### PR TITLE
#227 filter shared dataextensions (ending on "_Salesforce" or "_Salesforce_1")

### DIFF
--- a/copado-function/app/Retrieve.js
+++ b/copado-function/app/Retrieve.js
@@ -692,12 +692,13 @@ class Retrieve {
                             return;
                         }
                         if (
-                            this._getAttrValue(item, def.nameField).startsWith(
+                            type === 'dataExtension' &&
+                            (this._getAttrValue(item, def.nameField).startsWith(
                                 'QueryStudioResults at '
                             ) ||
-                            '/(_Salesforce)(_[0-9])?$/g'.test(
-                                this._getAttrValue(item, def.nameField)
-                            )
+                                '/(_Salesforce)(_[0-9])?$/g'.test(
+                                    this._getAttrValue(item, def.nameField)
+                                ))
                         ) {
                             return;
                         }

--- a/copado-function/app/Retrieve.js
+++ b/copado-function/app/Retrieve.js
@@ -694,6 +694,9 @@ class Retrieve {
                         if (
                             this._getAttrValue(item, def.nameField).startsWith(
                                 'QueryStudioResults at '
+                            ) ||
+                            '/(_Salesforce)(_[0-9])?$/g'.test(
+                                this._getAttrValue(item, def.nameField)
                             )
                         ) {
                             return;


### PR DESCRIPTION
# PR details

## What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [X] Bug fix
- [ ] New metadata support
- [ ] Enhanced Copado function
- [ ] Add a GUI option
- [ ] Add something to the core
- [ ] Other, please explain:

## What changes did you make? (Give an overview)

Changed retrieve.js, so it only retrieves records without the suffix "_Salesforce[_N]"
