### PR TITLE
#250: speed up attaching logs

### DIFF
--- a/copado-function/app/Commit.js
+++ b/copado-function/app/Commit.js
@@ -31,6 +31,7 @@
 
 const fs = require('node:fs');
 const execSync = require('node:child_process').execSync;
+const exec = require('node:child_process').exec;
 const resolve = require('node:path').resolve;
 
 const CONFIG = {
@@ -553,16 +554,26 @@ class Copado {
      * @returns {void}
      */
     static attachJson(metadataFilePath) {
-        this._attachFile(metadataFilePath, CONFIG.envId, 'Attach JSON ' + metadataFilePath);
+        Log.debug('Attach JSON ' + metadataFilePath + ' to ' + CONFIG.envId);
+        this._attachFile(metadataFilePath, CONFIG.envId);
     }
     /**
      * Finally, attach the resulting metadata JSON.
      *
-     * @param {string} metadataFilePath where we stored the temporary json file
-     * @returns {void}
+     * @param {string} localPath where we stored the temporary json file
+     * @returns {Promise.<void>} promise of log upload
      */
-    static attachLog(metadataFilePath) {
-        this._attachFile(metadataFilePath, null, 'Attach Custom Log ' + metadataFilePath);
+    static async attachLog(localPath) {
+        const command = `copado --uploadfile "${localPath}"`;
+        Log.debug('⚡ ' + command);
+
+        try {
+            exec(command);
+        } catch (ex) {
+            // do not use Log.error here to prevent our copado-function from auto-failing right here
+            Log.info(ex.status + ': ' + ex.message);
+            throw new Error(ex);
+        }
     }
 
     /**
@@ -658,19 +669,22 @@ class Copado {
     /**
      * to be executed at the very end
      *
-     * @returns {void}
+     * @returns {Promise.<void>} promise of uploads
      */
-    static uploadToolLogs() {
-        Log.progress('Getting mcdev logs');
+    static async uploadToolLogs() {
+        Log.debug('Getting mcdev logs');
 
         try {
+            const logsAttached = [];
             for (const file of fs.readdirSync('logs')) {
                 Log.debug('- ' + file);
-                Copado.attachLog('logs/' + file);
+                logsAttached.push(Copado.attachLog('logs/' + file));
             }
-            Log.progress('Attached mcdev logs');
+            const response = await Promise.all(logsAttached);
+            Log.debug('Attached mcdev logs');
+            return response;
         } catch (ex) {
-            Log.info('attaching mcdev logs failed:' + ex.message);
+            Log.debug('attaching mcdev logs failed:' + ex.message);
         }
     }
 }

--- a/copado-function/app/Retrieve.config
+++ b/copado-function/app/Retrieve.config
@@ -10,6 +10,7 @@
 * [Worker Size] (M)
 
 # Parameters needs to be configured for Marketing Cloud retrieve function
+* [env_id] ({$Source.Id}) 
 * [main_branch] ({$Pipeline.copado__Main_Branch__c}) 
 * [mcdev_version] ({$Pipeline.Property.mc_devtools_version}) # leave empty unless you want to use a specific version of the devtools installed on-the-fly
 * [git_json] ({$Context.Repository.Credential}) 

--- a/copado-function/app/Retrieve.js
+++ b/copado-function/app/Retrieve.js
@@ -31,6 +31,7 @@
 
 const fs = require('node:fs');
 const execSync = require('node:child_process').execSync;
+const exec = require('node:child_process').exec;
 const resolve = require('node:path').resolve;
 
 const CONFIG = {
@@ -183,6 +184,7 @@ async function run() {
         Log.info('Attach JSON');
         Log.info('===================');
         Log.info('');
+        Log.progress('Loading items into Copado');
         Copado.attachJson(CONFIG.metadataFilePath);
     } catch (ex) {
         Log.error('Attaching JSON file failed:' + ex.message);
@@ -514,16 +516,26 @@ class Copado {
      * @returns {void}
      */
     static attachJson(metadataFilePath) {
-        this._attachFile(metadataFilePath, CONFIG.envId, 'Attach JSON ' + metadataFilePath);
+        Log.debug('Attach JSON ' + metadataFilePath + ' to ' + CONFIG.envId);
+        this._attachFile(metadataFilePath, CONFIG.envId);
     }
     /**
      * Finally, attach the resulting metadata JSON.
      *
-     * @param {string} metadataFilePath where we stored the temporary json file
-     * @returns {void}
+     * @param {string} localPath where we stored the temporary json file
+     * @returns {Promise.<void>} promise of log upload
      */
-    static attachLog(metadataFilePath) {
-        this._attachFile(metadataFilePath, null, 'Attach Custom Log ' + metadataFilePath);
+    static async attachLog(localPath) {
+        const command = `copado --uploadfile "${localPath}"`;
+        Log.debug('⚡ ' + command);
+
+        try {
+            exec(command);
+        } catch (ex) {
+            // do not use Log.error here to prevent our copado-function from auto-failing right here
+            Log.info(ex.status + ': ' + ex.message);
+            throw new Error(ex);
+        }
     }
 
     /**
@@ -599,19 +611,22 @@ class Copado {
     /**
      * to be executed at the very end
      *
-     * @returns {void}
+     * @returns {Promise.<void>} promise of uploads
      */
-    static uploadToolLogs() {
-        Log.progress('Getting mcdev logs');
+    static async uploadToolLogs() {
+        Log.debug('Getting mcdev logs');
 
         try {
+            const logsAttached = [];
             for (const file of fs.readdirSync('logs')) {
                 Log.debug('- ' + file);
-                Copado.attachLog('logs/' + file);
+                logsAttached.push(Copado.attachLog('logs/' + file));
             }
-            Log.progress('Attached mcdev logs');
+            const response = await Promise.all(logsAttached);
+            Log.debug('Attached mcdev logs');
+            return response;
         } catch (ex) {
-            Log.info('attaching mcdev logs failed:' + ex.message);
+            Log.debug('attaching mcdev logs failed:' + ex.message);
         }
     }
 }


### PR DESCRIPTION
# PR details

## What is the purpose of this pull request? (put an "X" next to an item)

closes #250 

## Outcome
reduces time for tool uploads from 10 to <1 second:

## BEFORE
![image](https://user-images.githubusercontent.com/1917227/198032637-e0d28cb0-a6fd-4b3c-8315-bdea13b11d49.png)
and 
![image](https://user-images.githubusercontent.com/1917227/198032740-3b9ee3db-daf2-4c13-821c-037488296e25.png)


## AFTER
(retrieve)
![image](https://user-images.githubusercontent.com/1917227/198032462-68b88d30-192c-43a8-83d8-5944b998dbe6.png)

(commit)
![image](https://user-images.githubusercontent.com/1917227/198034383-862fcbbf-c0c7-4394-a076-5291f9a21389.png)
