### PR TITLE
#262: allow 1:n deployemts on single target BU

### DIFF
--- a/copado-function/app/Deploy.config
+++ b/copado-function/app/Deploy.config
@@ -26,6 +26,7 @@
 * sourceProperties ({$Context.apex.mcdo_GetPropertiesOfUSsInPromotion})
 * target_mid ({$Destination.Property.mid})
 * [debug]   ({$Pipeline.Property.debug})
+* [deployNTimes] ({$Pipeline.Property.deployNTimes})
 * [envVariablesDestination] ({$Destination.apex.EnvironmentVariables})
 * [envVariablesDestinationChildren] ({$Destination.apex.mcdo_ChildEnvironmentVariables})
 * [envVariablesSource] ({$Context.apex.mcdo_SourceEnvironmentVariables})

--- a/copado-function/app/Deploy.js
+++ b/copado-function/app/Deploy.js
@@ -92,6 +92,7 @@ const CONFIG = {
     promotionName: process.env.promotionName, // The promotion name of a PR
     target_mid: process.env.target_mid,
     sourceProperties: process.env.sourceProperties,
+    deploy1toN: true, // TODO: define somehow in Copado GUI! ; process.env.deploy1toN === 'true' ? true : false,
 };
 
 /**
@@ -1082,6 +1083,21 @@ class Deploy {
         // ensure the system knows what we name our market lists for deployment
         config.options.deployment.sourceTargetMapping = {};
         config.options.deployment.sourceTargetMapping[deploySourceList] = deployTargetList;
+
+        // set up corresponding markets and remove other entries
+        config.markets = {};
+        config.markets['source'] = marketVariables.source;
+        config.markets['target'] = marketVariables.destination;
+
+        if (CONFIG.deploy1toN) {
+            // add markets for child BUs
+            for (const childSfid in CONFIG.envVariables.destinationChildren) {
+                config.markets[childSfid] = CONFIG.envVariables.destinationChildren[childSfid];
+            }
+        }
+        // TODO: deal with parent BU deployments (sourceChildren / destinationChildren)
+        // TODO: deal with enterprise BU deployments (shared DEs)
+
         // remove potentially existing entries and ensure these 2 lists exist
         config.marketList = {};
         for (const listName of [deploySourceList, deployTargetList]) {
@@ -1089,13 +1105,15 @@ class Deploy {
         }
         // add marketList entries for the 2 bu-market combos
         config.marketList[deploySourceList][sourceBU] = 'source';
-        config.marketList[deployTargetList][targetBU] = 'target';
-        // set up corresponding markets and remove other entries
-        config.markets = {};
-        config.markets['source'] = marketVariables.source;
-        config.markets['target'] = marketVariables.destination;
-        // TODO: deal with parent BU deployments (sourceChildren / destinationChildren)
-        // TODO: deal with enterprise BU deployments (shared DEs)
+        if (CONFIG.deploy1toN) {
+            // add list of markets variables for the child BUs to the target BU to deploy components more than once to the same BU
+            config.marketList[deployTargetList][targetBU] = Object.keys(
+                CONFIG.envVariables.destinationChildren
+            );
+        } else {
+            // standard 1:1 deployment
+            config.marketList[deployTargetList][targetBU] = 'target';
+        }
 
         console.log(
             'config.options.deployment.sourceTargetMapping',

--- a/copado-function/app/Deploy.js
+++ b/copado-function/app/Deploy.js
@@ -92,7 +92,7 @@ const CONFIG = {
     promotionName: process.env.promotionName, // The promotion name of a PR
     target_mid: process.env.target_mid,
     sourceProperties: process.env.sourceProperties,
-    deploy1toN: true, // TODO: define somehow in Copado GUI! ; process.env.deploy1toN === 'true' ? true : false,
+    deployNTimes: process.env.deployNTimes === 'true' ? true : false,
 };
 
 /**
@@ -1089,7 +1089,7 @@ class Deploy {
         config.markets['source'] = marketVariables.source;
         config.markets['target'] = marketVariables.destination;
 
-        if (CONFIG.deploy1toN) {
+        if (CONFIG.deployNTimes) {
             // add markets for child BUs
             for (const childSfid in CONFIG.envVariables.destinationChildren) {
                 config.markets[childSfid] = CONFIG.envVariables.destinationChildren[childSfid];
@@ -1105,7 +1105,7 @@ class Deploy {
         }
         // add marketList entries for the 2 bu-market combos
         config.marketList[deploySourceList][sourceBU] = 'source';
-        if (CONFIG.deploy1toN) {
+        if (CONFIG.deployNTimes) {
             // add list of markets variables for the child BUs to the target BU to deploy components more than once to the same BU
             config.marketList[deployTargetList][targetBU] = Object.keys(
                 CONFIG.envVariables.destinationChildren


### PR DESCRIPTION
# PR details

## What is the purpose of this pull request? (put an "X" next to an item)

closes #262 

should allow us to deploy 1 query / DE / whatever multiple times to the same BU, if that BU was set up as parent to other BUs AND if environment variables lead to adding a suffix or prefix 

**TODO:** Define 1:1 vs 1:n deployment mode in GUI

FYI @nrabe-copado 