### PR TITLE
264 feature auto get child envs of child if there are any

### DIFF
--- a/copado-function/app/Commit.js
+++ b/copado-function/app/Commit.js
@@ -338,7 +338,7 @@ class Util {
      */
     static push(destinationBranch) {
         Util.execCommand(
-            'Push branch ' + destinationBranch,
+            `Pushing updates to ${destinationBranch} branch`,
             ['git push origin "' + destinationBranch + '"'],
             'Completed pushing branch'
         );
@@ -659,7 +659,7 @@ class Copado {
      */
     static checkoutSrc(workingBranch, createBranch = false) {
         Util.execCommand(
-            'Switching to branch ' + workingBranch,
+            `Switching to ${workingBranch} branch`,
             [`copado-git-get ${createBranch ? '--create ' : ''}"${workingBranch}"`],
             'Completed creating/checking out branch'
         );
@@ -674,12 +674,12 @@ class Copado {
     static deleteBranch(featureBranch) {
         // delete feature branch on origin code in here
         Util.execCommand(
-            'Deleting server branch ' + featureBranch,
+            `Deleting branch ${featureBranch} on server`,
             [`git push origin --delete ${featureBranch}`],
             'Completed deleting server branch ' + featureBranch
         );
         Util.execCommand(
-            'Deleting local branch ' + featureBranch,
+            `Deleting branch ${featureBranch} locally`,
             [`git branch --delete --force ${featureBranch}`],
             'Completed deleting local branch ' + featureBranch
         );
@@ -799,7 +799,7 @@ class Commit {
         Log.debug(gitDiffArr);
         if (Array.isArray(gitDiffArr) && gitDiffArr.length) {
             Util.execCommand(
-                'Committing changes',
+                'Committing changes to branch',
                 ['git commit -n -m "' + CONFIG.commitMessage + '"'],
                 'Completed committing'
             );

--- a/copado-function/app/Deploy.js
+++ b/copado-function/app/Deploy.js
@@ -419,7 +419,7 @@ class Util {
      */
     static push(destinationBranch) {
         Util.execCommand(
-            'Push branch ' + destinationBranch,
+            `Pushing updates to ${destinationBranch} branch`,
             ['git push origin "' + destinationBranch + '"'],
             'Completed pushing branch'
         );
@@ -752,7 +752,7 @@ class Copado {
      */
     static checkoutSrc(workingBranch, createBranch = false) {
         Util.execCommand(
-            'Switching to branch ' + workingBranch,
+            `Switching to ${workingBranch} branch`,
             [`copado-git-get ${createBranch ? '--create ' : ''}"${workingBranch}"`],
             'Completed creating/checking out branch'
         );
@@ -874,7 +874,7 @@ class Commit {
         Log.debug(gitDiffArr);
         if (Array.isArray(gitDiffArr) && gitDiffArr.length) {
             Util.execCommand(
-                'Commit',
+                'Committing changes to branch',
                 ['git commit -n -m "' + CONFIG.commitMessage + '"'],
                 'Completed committing'
             );

--- a/copado-function/app/Retrieve.js
+++ b/copado-function/app/Retrieve.js
@@ -305,7 +305,7 @@ class Util {
      */
     static push(destinationBranch) {
         Util.execCommand(
-            'Push branch ' + destinationBranch,
+            `Pushing updates to ${destinationBranch} branch`,
             ['git push origin "' + destinationBranch + '"'],
             'Completed pushing branch'
         );
@@ -625,7 +625,7 @@ class Copado {
      */
     static checkoutSrc(workingBranch, createBranch = false) {
         Util.execCommand(
-            'Switching to branch ' + workingBranch,
+            `Switching to ${workingBranch} branch`,
             [`copado-git-get ${createBranch ? '--create ' : ''}"${workingBranch}"`],
             'Completed creating/checking out branch'
         );

--- a/copado-function/app/mcdev-retrieveTypes.config
+++ b/copado-function/app/mcdev-retrieveTypes.config
@@ -1,0 +1,32 @@
+"metaDataTypes": {
+    "retrieve": [
+        "asset-archive",
+        "asset-asset",
+        "asset-audio",
+        "asset-block",
+        "asset-code",
+        "asset-document",
+        "asset-image",
+        "asset-message",
+        "asset-other",
+        "asset-rawimage",
+        "asset-template",
+        "asset-textfile",
+        "asset-video",
+        "automation",
+        "dataExtract",
+        "fileTransfer",
+        "importFile",
+        "script",
+        "query",
+        "dataExtension",
+        "emailSendDefinition",
+        "ftpLocation",
+        "list",
+        "mobileCode",
+        "mobileKeyword",
+        "role",
+        "triggeredSendDefinition"
+    ],
+    "documentOnRetrieve": ["accountUser", "automation", "dataExtension", "role"]
+}

--- a/force-app/main/default/classes/mcdo_ChildEnvironmentVariables.cls
+++ b/force-app/main/default/classes/mcdo_ChildEnvironmentVariables.cls
@@ -6,6 +6,8 @@ global with sharing class mcdo_ChildEnvironmentVariables implements copado.Param
     private Map<String, List<EnvironmentVariablesRecord>> envVariablesByEnvName = new Map<String, List<EnvironmentVariablesRecord>>();
 
     global String execute(Id environmentId) {
+        environmentId = getParentEnvironmentId(environmentId);
+
         List<Environment> result = new List<Environment>();
         for (
             copado__Environmental_Variable__c environmentVariable : getEnvironmentVariables(
@@ -59,6 +61,41 @@ global with sharing class mcdo_ChildEnvironmentVariables implements copado.Param
             WHERE mcdo_Parent_Environment__c = :environmentId
             WITH SECURITY_ENFORCED
         ];
+    }
+
+    // used in case of stacked parent BUs - but only if the current env has mcdo_Is_Enterprise_BU__c==true
+    private Id getParentEnvironmentId(Id environmentId) {
+        copado__Environment__c currentEnv = [
+            SELECT Id, mcdo_Is_Enterprise_BU__c
+            FROM copado__Environment__c
+            WHERE Id = :environmentId
+            WITH SECURITY_ENFORCED
+        ];
+        if (currentEnv.mcdo_Is_Enterprise_BU__c) {
+            // check if there is only one child
+            List<copado__Environment__c> children = [
+                SELECT Id, Name
+                FROM copado__Environment__c
+                WHERE mcdo_Parent_Environment__c = :environmentId
+                WITH SECURITY_ENFORCED
+            ];
+            if (!children.isEmpty() && children.size() == 1) {
+                // check if child has children itself
+                Id childEnvId = children[0].Id;
+                List<copado__Environment__c> childrenOfChild = [
+                    SELECT Id, Name
+                    FROM copado__Environment__c
+                    WHERE mcdo_Parent_Environment__c = :childEnvId
+                    WITH SECURITY_ENFORCED
+                ];
+                if (!childrenOfChild.isEmpty() && childrenOfChild.size() > 0) {
+                    // if 1..n children are found, we want the rest of the code show variables for those environments instead
+                    return childEnvId;
+                }
+            }
+        }
+        // fallback; return what we've already had in the beginning
+        return environmentId;
     }
 
     // WRAPPER

--- a/force-app/main/default/flexipages/Environment_Record_Page2.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/Environment_Record_Page2.flexipage-meta.xml
@@ -48,6 +48,7 @@
                     <value>3</value>
                 </componentInstanceProperties>
                 <componentName>force:highlightsPanel</componentName>
+                <identifier>force_highlightsPanel</identifier>
             </componentInstance>
         </itemInstances>
         <mode>Replace</mode>
@@ -62,6 +63,7 @@
                     <value>required</value>
                 </fieldInstanceProperties>
                 <fieldItem>Record.Name</fieldItem>
+                <identifier>RecordNameField</identifier>
             </fieldInstance>
         </itemInstances>
         <itemInstances>
@@ -71,6 +73,7 @@
                     <value>required</value>
                 </fieldInstanceProperties>
                 <fieldItem>Record.copado__Platform__c</fieldItem>
+                <identifier>RecordPlatform__cField</identifier>
             </fieldInstance>
         </itemInstances>
         <itemInstances>
@@ -80,11 +83,17 @@
                     <value>none</value>
                 </fieldInstanceProperties>
                 <fieldItem>Record.copado__Type__c</fieldItem>
+                <identifier>RecordType__cField</identifier>
             </fieldInstance>
         </itemInstances>
         <itemInstances>
             <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
                 <fieldItem>Record.copado__Last_Refresh_Date__c</fieldItem>
+                <identifier>RecordLast_Refresh_Date__cField</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.copado__Type__c}</leftValue>
@@ -101,6 +110,7 @@
                     <value>readonly</value>
                 </fieldInstanceProperties>
                 <fieldItem>Record.CreatedById</fieldItem>
+                <identifier>RecordCreatedByIdField</identifier>
             </fieldInstance>
         </itemInstances>
         <name>Facet-399a3bdd-4559-4656-8578-00a11edfb70b</name>
@@ -114,6 +124,41 @@
                     <value>none</value>
                 </fieldInstanceProperties>
                 <fieldItem>Record.OwnerId</fieldItem>
+                <identifier>RecordOwnerIdField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.mcdo_Parent_Environment__c</fieldItem>
+                <identifier>Recordmcdo_Parent_Environment_cField</identifier>
+                <visibilityRule>
+                    <criteria>
+                        <leftValue>{!Record.copado__Platform__c}</leftValue>
+                        <operator>EQUAL</operator>
+                        <rightValue>Marketing Cloud</rightValue>
+                    </criteria>
+                </visibilityRule>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.mcdo_Is_Enterprise_BU__c</fieldItem>
+                <identifier>Recordmcdo_Is_Enterprise_BU_cField</identifier>
+                <visibilityRule>
+                    <criteria>
+                        <leftValue>{!Record.copado__Platform__c}</leftValue>
+                        <operator>EQUAL</operator>
+                        <rightValue>Marketing Cloud</rightValue>
+                    </criteria>
+                </visibilityRule>
             </fieldInstance>
         </itemInstances>
         <itemInstances>
@@ -123,6 +168,7 @@
                     <value>none</value>
                 </fieldInstanceProperties>
                 <fieldItem>Record.copado__Namespace__c</fieldItem>
+                <identifier>RecordNamespace__cField</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.copado__Platform__c}</leftValue>
@@ -139,18 +185,30 @@
                     <value>none</value>
                 </fieldInstanceProperties>
                 <fieldItem>Record.copado__Org_ID__c</fieldItem>
+                <identifier>RecordOrg_ID__cField</identifier>
                 <visibilityRule>
+                    <booleanFilter>1 OR 2</booleanFilter>
                     <criteria>
                         <leftValue>{!Record.copado__Platform__c}</leftValue>
                         <operator>EQUAL</operator>
                         <rightValue>Salesforce</rightValue>
+                    </criteria>
+                    <criteria>
+                        <leftValue>{!Record.copado__Platform__c}</leftValue>
+                        <operator>EQUAL</operator>
+                        <rightValue>Marketing Cloud</rightValue>
                     </criteria>
                 </visibilityRule>
             </fieldInstance>
         </itemInstances>
         <itemInstances>
             <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
                 <fieldItem>Record.copado__Run_all_tests__c</fieldItem>
+                <identifier>RecordRun_all_tests__cField</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.copado__Platform__c}</leftValue>
@@ -167,6 +225,7 @@
                     <value>readonly</value>
                 </fieldInstanceProperties>
                 <fieldItem>Record.LastModifiedById</fieldItem>
+                <identifier>RecordLastModifiedByIdField</identifier>
             </fieldInstance>
         </itemInstances>
         <name>Facet-3e90233f-40d5-44f8-bb2f-b614f3f29e91</name>
@@ -180,6 +239,7 @@
                     <value>Facet-399a3bdd-4559-4656-8578-00a11edfb70b</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:column</componentName>
+                <identifier>flexipage_column</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
@@ -189,6 +249,7 @@
                     <value>Facet-3e90233f-40d5-44f8-bb2f-b614f3f29e91</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:column</componentName>
+                <identifier>flexipage_column2</identifier>
             </componentInstance>
         </itemInstances>
         <name>Facet-3f3a5028-3c07-4e07-82e6-7a8d0e143883</name>
@@ -202,6 +263,7 @@
                     <value>none</value>
                 </fieldInstanceProperties>
                 <fieldItem>Record.copado__Promotion_Default_Credential__c</fieldItem>
+                <identifier>RecordPromotion_Default_Credential__cField</identifier>
             </fieldInstance>
         </itemInstances>
         <itemInstances>
@@ -211,6 +273,7 @@
                     <value>none</value>
                 </fieldInstanceProperties>
                 <fieldItem>Record.copado__Validation_Promotion_Default_Credential__c</fieldItem>
+                <identifier>RecordValidation_Promotion_Default_Credential__cField</identifier>
             </fieldInstance>
         </itemInstances>
         <itemInstances>
@@ -220,6 +283,7 @@
                     <value>none</value>
                 </fieldInstanceProperties>
                 <fieldItem>Record.copado__Index_Back_Promotion_metadata__c</fieldItem>
+                <identifier>RecordIndex_Back_Promotion_metadata__cField</identifier>
             </fieldInstance>
         </itemInstances>
         <name>Facet-1d9aaa38-0af2-48ba-b5bd-0a10e8bcec42</name>
@@ -233,6 +297,7 @@
                     <value>none</value>
                 </fieldInstanceProperties>
                 <fieldItem>Record.copado__Connection_Behavior__c</fieldItem>
+                <identifier>RecordConnection_Behavior__cField</identifier>
             </fieldInstance>
         </itemInstances>
         <itemInstances>
@@ -242,6 +307,7 @@
                     <value>readonly</value>
                 </fieldInstanceProperties>
                 <fieldItem>Record.copado__Latest_Deployment__c</fieldItem>
+                <identifier>RecordLatest_Deployment__cField</identifier>
             </fieldInstance>
         </itemInstances>
         <itemInstances>
@@ -251,6 +317,7 @@
                     <value>none</value>
                 </fieldInstanceProperties>
                 <fieldItem>Record.copado__Deployment_Automation_Override__c</fieldItem>
+                <identifier>RecordDeployment_Automation_Override__cField</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.copado__Platform__c}</leftValue>
@@ -262,7 +329,63 @@
         </itemInstances>
         <itemInstances>
             <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.copado__Deployment_Job_Template_Override__c</fieldItem>
+                <identifier>RecordDeployment_Job_Template_Override__cField</identifier>
+                <visibilityRule>
+                    <criteria>
+                        <leftValue>{!Record.copado__Platform__c}</leftValue>
+                        <operator>NE</operator>
+                        <rightValue>Salesforce</rightValue>
+                    </criteria>
+                </visibilityRule>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
                 <fieldItem>Record.copado__Promotion_Override__c</fieldItem>
+                <identifier>RecordPromotion_Override__cField</identifier>
+                <visibilityRule>
+                    <criteria>
+                        <leftValue>{!Record.copado__Platform__c}</leftValue>
+                        <operator>NE</operator>
+                        <rightValue>Salesforce</rightValue>
+                    </criteria>
+                </visibilityRule>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.copado__Promotion_Job_Template_Override__c</fieldItem>
+                <identifier>RecordPromotion_Job_Template_Override__cField</identifier>
+                <visibilityRule>
+                    <criteria>
+                        <leftValue>{!Record.copado__Platform__c}</leftValue>
+                        <operator>NE</operator>
+                        <rightValue>Salesforce</rightValue>
+                    </criteria>
+                </visibilityRule>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.copado__CommitJobTemplateOverride__c</fieldItem>
+                <identifier>RecordCommitJobTemplateOverride__cField</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.copado__Platform__c}</leftValue>
@@ -283,6 +406,7 @@
                     <value>Facet-1d9aaa38-0af2-48ba-b5bd-0a10e8bcec42</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:column</componentName>
+                <identifier>flexipage_column3</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
@@ -292,9 +416,52 @@
                     <value>Facet-6548003e-3b4f-48e1-ae59-6321f03586d0</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:column</componentName>
+                <identifier>flexipage_column4</identifier>
             </componentInstance>
         </itemInstances>
         <name>Facet-eb053938-a3d9-43b6-beeb-26d93cde682f</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+    <flexiPageRegions>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.copado__Enable_Rollback__c</fieldItem>
+                <identifier>RecordEnable_Rollback__cField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <name>Facet-0794ed0e-e209-4713-aab4-34504452200d</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+    <flexiPageRegions>
+        <name>Facet-0605b273-5c14-4ba1-a196-f39107951dac</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+    <flexiPageRegions>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>body</name>
+                    <value>Facet-0794ed0e-e209-4713-aab4-34504452200d</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:column</componentName>
+                <identifier>flexipage_column5</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>body</name>
+                    <value>Facet-0605b273-5c14-4ba1-a196-f39107951dac</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:column</componentName>
+                <identifier>flexipage_column6</identifier>
+            </componentInstance>
+        </itemInstances>
+        <name>Facet-11df1ef6-f64f-40af-8b4d-4812535ba726</name>
         <type>Facet</type>
     </flexiPageRegions>
     <flexiPageRegions>
@@ -309,6 +476,7 @@
                     <value>Information</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:fieldSection</componentName>
+                <identifier>flexipage_fieldSection</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
@@ -322,6 +490,28 @@
                     <value>Pipeline Behavior</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:fieldSection</componentName>
+                <identifier>flexipage_fieldSection2</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>columns</name>
+                    <value>Facet-11df1ef6-f64f-40af-8b4d-4812535ba726</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>label</name>
+                    <value>Rollback</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:fieldSection</componentName>
+                <identifier>flexipage_fieldSection3</identifier>
+                <visibilityRule>
+                    <criteria>
+                        <leftValue>{!Record.copado__Platform__c}</leftValue>
+                        <operator>EQUAL</operator>
+                        <rightValue>Salesforce</rightValue>
+                    </criteria>
+                </visibilityRule>
             </componentInstance>
         </itemInstances>
         <mode>Replace</mode>
@@ -352,6 +542,7 @@
                     <value>true</value>
                 </componentInstanceProperties>
                 <componentName>force:relatedListSingleContainer</componentName>
+                <identifier>force_relatedListSingleContainer</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
@@ -377,6 +568,7 @@
                     <value>true</value>
                 </componentInstanceProperties>
                 <componentName>force:relatedListSingleContainer</componentName>
+                <identifier>force_relatedListSingleContainer2</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
@@ -402,6 +594,7 @@
                     <value>true</value>
                 </componentInstanceProperties>
                 <componentName>force:relatedListSingleContainer</componentName>
+                <identifier>force_relatedListSingleContainer3</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.copado__Platform__c}</leftValue>
@@ -422,6 +615,7 @@
                     <value>none</value>
                 </fieldInstanceProperties>
                 <fieldItem>Record.copado__Run_all_tests__c</fieldItem>
+                <identifier>RecordRun_all_tests__cField2</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.copado__Platform__c}</leftValue>
@@ -438,6 +632,7 @@
                     <value>none</value>
                 </fieldInstanceProperties>
                 <fieldItem>Record.copado__Current_Code_Coverage__c</fieldItem>
+                <identifier>RecordCurrent_Code_Coverage__cField</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.copado__Platform__c}</leftValue>
@@ -458,6 +653,7 @@
                     <value>none</value>
                 </fieldInstanceProperties>
                 <fieldItem>Record.copado__Minimum_Apex_Test_Coverage__c</fieldItem>
+                <identifier>RecordMinimum_Apex_Test_Coverage__cField</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.copado__Platform__c}</leftValue>
@@ -478,6 +674,7 @@
                     <value>Facet-979a9bcd-a45b-42ea-8d5e-e81c30f12f9d</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:column</componentName>
+                <identifier>flexipage_column7</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
@@ -487,6 +684,7 @@
                     <value>Facet-e39a9b96-5b2e-40b3-8ee5-5e8aaaf9251c</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:column</componentName>
+                <identifier>flexipage_column8</identifier>
             </componentInstance>
         </itemInstances>
         <name>Facet-d66b2f56-549b-41a2-bc13-6436c8677348</name>
@@ -500,6 +698,7 @@
                     <value>readonly</value>
                 </fieldInstanceProperties>
                 <fieldItem>Record.copado__Current_SCA_Score__c</fieldItem>
+                <identifier>RecordCurrent_SCA_Score__cField</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.copado__Platform__c}</leftValue>
@@ -520,6 +719,7 @@
                     <value>none</value>
                 </fieldInstanceProperties>
                 <fieldItem>Record.copado__Maximum_SCA_Score__c</fieldItem>
+                <identifier>RecordMaximum_SCA_Score__cField</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.copado__Platform__c}</leftValue>
@@ -540,6 +740,7 @@
                     <value>Facet-a6a9089a-f1b0-4dfb-b9f4-6b925d478452</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:column</componentName>
+                <identifier>flexipage_column9</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
@@ -549,6 +750,7 @@
                     <value>Facet-003c39f8-eeb6-48d1-9b98-c6048dfcd133</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:column</componentName>
+                <identifier>flexipage_column10</identifier>
             </componentInstance>
         </itemInstances>
         <name>Facet-b85523e1-ad5d-474d-b9a8-7ad7fdb750bc</name>
@@ -562,6 +764,7 @@
                     <value>none</value>
                 </fieldInstanceProperties>
                 <fieldItem>Record.copado__Compliance_Rule_Group__c</fieldItem>
+                <identifier>RecordCompliance_Rule_Group__cField</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.copado__Platform__c}</leftValue>
@@ -578,6 +781,7 @@
                     <value>none</value>
                 </fieldInstanceProperties>
                 <fieldItem>Record.copado__Compliance_Scan_Events__c</fieldItem>
+                <identifier>RecordCompliance_Scan_Events__cField</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.copado__Platform__c}</leftValue>
@@ -598,6 +802,7 @@
                     <value>readonly</value>
                 </fieldInstanceProperties>
                 <fieldItem>Record.copado__Compliance_Status__c</fieldItem>
+                <identifier>RecordCompliance_Status__cField</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.copado__Platform__c}</leftValue>
@@ -614,6 +819,7 @@
                     <value>readonly</value>
                 </fieldInstanceProperties>
                 <fieldItem>Record.copado__Last_Compliance_Scan_Date__c</fieldItem>
+                <identifier>RecordLast_Compliance_Scan_Date__cField</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.copado__Platform__c}</leftValue>
@@ -634,6 +840,7 @@
                     <value>Facet-45c34725-396b-4451-b720-06ae22db31f7</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:column</componentName>
+                <identifier>flexipage_column11</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
@@ -643,6 +850,7 @@
                     <value>Facet-5dde8b00-7ffc-424b-828a-6994b97de012</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:column</componentName>
+                <identifier>flexipage_column12</identifier>
             </componentInstance>
         </itemInstances>
         <name>Facet-0278f65e-ac01-4aa5-9d3c-2ad15336fd6d</name>
@@ -660,6 +868,7 @@
                     <value>Code Coverage</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:fieldSection</componentName>
+                <identifier>flexipage_fieldSection4</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.copado__Platform__c}</leftValue>
@@ -680,6 +889,7 @@
                     <value>Static Code Analysis</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:fieldSection</componentName>
+                <identifier>flexipage_fieldSection5</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.copado__Platform__c}</leftValue>
@@ -700,6 +910,7 @@
                     <value>Compliance</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:fieldSection</componentName>
+                <identifier>flexipage_fieldSection6</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.copado__Platform__c}</leftValue>
@@ -732,6 +943,7 @@
                     <value>true</value>
                 </componentInstanceProperties>
                 <componentName>force:relatedListSingleContainer</componentName>
+                <identifier>force_relatedListSingleContainer4</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.copado__Platform__c}</leftValue>
@@ -764,6 +976,7 @@
                     <value>true</value>
                 </componentInstanceProperties>
                 <componentName>force:relatedListSingleContainer</componentName>
+                <identifier>force_relatedListSingleContainer5</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.copado__Platform__c}</leftValue>
@@ -796,6 +1009,7 @@
                     <value>true</value>
                 </componentInstanceProperties>
                 <componentName>force:relatedListSingleContainer</componentName>
+                <identifier>force_relatedListSingleContainer6</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.copado__Platform__c}</leftValue>
@@ -816,6 +1030,7 @@
                     <value>&lt;p&gt;Quality Gates are currently not supported for this type of Environment.&lt;/p&gt;</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:richText</componentName>
+                <identifier>flexipage_richText</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.copado__Platform__c}</leftValue>
@@ -852,31 +1067,18 @@
                     <value>true</value>
                 </componentInstanceProperties>
                 <componentName>force:relatedListSingleContainer</componentName>
-                <visibilityRule>
-                    <criteria>
-                        <leftValue>{!Record.copado__Platform__c}</leftValue>
-                        <operator>EQUAL</operator>
-                        <rightValue>Salesforce</rightValue>
-                    </criteria>
-                </visibilityRule>
+                <identifier>force_relatedListSingleContainer7</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
             <componentInstance>
-                <componentInstanceProperties>
-                    <name>decorate</name>
-                    <value>true</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>richTextValue</name>
-                    <value>&lt;p&gt;There are no Environment Variables for this type of Environment.&lt;/p&gt;</value>
-                </componentInstanceProperties>
-                <componentName>flexipage:richText</componentName>
+                <componentName>mcdo_ChildEnvironmentVariables</componentName>
+                <identifier>c_mcdo_ChildEnvironmentVariables2</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.copado__Platform__c}</leftValue>
-                        <operator>NE</operator>
-                        <rightValue>Salesforce</rightValue>
+                        <operator>EQUAL</operator>
+                        <rightValue>Marketing Cloud</rightValue>
                     </criteria>
                 </visibilityRule>
             </componentInstance>
@@ -908,6 +1110,7 @@
                     <value>true</value>
                 </componentInstanceProperties>
                 <componentName>force:relatedListSingleContainer</componentName>
+                <identifier>force_relatedListSingleContainer8</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.copado__Platform__c}</leftValue>
@@ -940,6 +1143,7 @@
                     <value>true</value>
                 </componentInstanceProperties>
                 <componentName>force:relatedListSingleContainer</componentName>
+                <identifier>force_relatedListSingleContainer9</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.copado__Platform__c}</leftValue>
@@ -960,6 +1164,7 @@
                     <value>&lt;p&gt;There are no External CI Jobs for this type of Environment.&lt;/p&gt;</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:richText</componentName>
+                <identifier>flexipage_richText2</identifier>
                 <visibilityRule>
                     <criteria>
                         <leftValue>{!Record.copado__Platform__c}</leftValue>
@@ -996,6 +1201,7 @@
                     <value>true</value>
                 </componentInstanceProperties>
                 <componentName>force:relatedListSingleContainer</componentName>
+                <identifier>force_relatedListSingleContainer10</identifier>
             </componentInstance>
         </itemInstances>
         <name>Facet-973df545-4218-4870-85e6-01917e967795</name>
@@ -1017,6 +1223,7 @@
                     <value>Standard.Tab.detail</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:tab</componentName>
+                <identifier>detailTab</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
@@ -1030,6 +1237,7 @@
                     <value>Pipelines</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:tab</componentName>
+                <identifier>customTab</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
@@ -1043,6 +1251,7 @@
                     <value>Quality Gates</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:tab</componentName>
+                <identifier>customTab2</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
@@ -1056,6 +1265,7 @@
                     <value>Environment Variables</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:tab</componentName>
+                <identifier>customTab3</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
@@ -1069,6 +1279,7 @@
                     <value>External CI</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:tab</componentName>
+                <identifier>customTab4</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
@@ -1082,6 +1293,7 @@
                     <value>System Properties</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:tab</componentName>
+                <identifier>customTab5</identifier>
             </componentInstance>
         </itemInstances>
         <mode>Replace</mode>
@@ -1096,6 +1308,7 @@
                     <value>maintabs</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:tabset</componentName>
+                <identifier>flexipage_tabset</identifier>
             </componentInstance>
         </itemInstances>
         <mode>Replace</mode>
@@ -1126,6 +1339,7 @@
                     <value>true</value>
                 </componentInstanceProperties>
                 <componentName>force:relatedListSingleContainer</componentName>
+                <identifier>force_relatedListSingleContainer11</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
@@ -1151,6 +1365,7 @@
                     <value>true</value>
                 </componentInstanceProperties>
                 <componentName>force:relatedListSingleContainer</componentName>
+                <identifier>force_relatedListSingleContainer12</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
@@ -1176,6 +1391,39 @@
                     <value>true</value>
                 </componentInstanceProperties>
                 <componentName>force:relatedListSingleContainer</componentName>
+                <identifier>force_relatedListSingleContainer13</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentName>mcdo_ChildEnvironmentVariables</componentName>
+                <identifier>c_mcdo_ChildEnvironmentVariables</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>parentFieldApiName</name>
+                    <value>copado__Environment__c.Id</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>relatedListApiName</name>
+                    <value>Environments__r</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>relatedListComponentOverride</name>
+                    <value>NONE</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>rowsToDisplay</name>
+                    <value>10</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>showActionBar</name>
+                    <value>true</value>
+                </componentInstanceProperties>
+                <componentName>force:relatedListSingleContainer</componentName>
+                <identifier>force_relatedListSingleContainer14</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>
@@ -1201,6 +1449,7 @@
                     <value>true</value>
                 </componentInstanceProperties>
                 <componentName>force:relatedListSingleContainer</componentName>
+                <identifier>force_relatedListSingleContainer1</identifier>
             </componentInstance>
         </itemInstances>
         <mode>Replace</mode>

--- a/force-app/main/default/layouts/copado__Environment__c-copado__Environment Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/copado__Environment__c-copado__Environment Layout.layout-meta.xml
@@ -66,6 +66,10 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
+                <field>mcdo_Is_Enterprise_BU__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
                 <field>copado__Latest_Deployment__c</field>
             </layoutItems>
         </layoutColumns>

--- a/force-app/main/default/objects/copado__Environment__c/fields/mcdo_Is_Enterprise_BU__c.field-meta.xml
+++ b/force-app/main/default/objects/copado__Environment__c/fields/mcdo_Is_Enterprise_BU__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>mcdo_Is_Enterprise_BU__c</fullName>
+    <defaultValue>false</defaultValue>
+    <description>if custom &quot;Parent BUs&quot; are created, shared DataExtensions still live on the real ParentBU. To manage 1:n deployments of these, we want to get environment variables from the country/market BUs and not from these custom &quot;Parent BUs&quot;. Please note that in such a scenario one would create multiple environments for the same EID/MID, 1 for match each custom &quot;Parent BU&quot;</description>
+    <externalId>false</externalId>
+    <inlineHelpText>If activated, it is tried to retrieve Child Environment Variables not from direct children but from the children of the 1 child that this BU has. Only required if you have custom &quot;Parent BUs&quot; created for your DEV/QA/PROD setup and did not use the actual ParentBU for integrations.</inlineHelpText>
+    <label>Is Enterprise BU</label>
+    <trackTrending>false</trackTrending>
+    <type>Checkbox</type>
+</CustomField>

--- a/force-app/main/default/permissionsets/Copado_Marketing_Cloud.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Copado_Marketing_Cloud.permissionset-meta.xml
@@ -51,6 +51,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>copado__Environment__c.mcdo_Is_Enterprise_BU__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>copado__Environment__c.mcdo_Parent_Environment__c</field>
         <readable>true</readable>
     </fieldPermissions>


### PR DESCRIPTION
# PR details

## What is the purpose of this pull request? (put an "X" next to an item)

closes #264 

allows deploying shared dataExtensions in 1:n mode even if custom "Parent BUs" were created