### PR TITLE
#283 show number of committed/deployed metadata items and number of files

### DIFF
--- a/copado-function/app/Commit.js
+++ b/copado-function/app/Commit.js
@@ -815,8 +815,8 @@ class Commit {
             Log.result(
                 result,
                 `Committed ${
-                    result.committed.filter((file) => file.endsWith('.json')).length
-                } items`
+                    result.committed.filter((item) => item.endsWith('.json')).length
+                } items with ${result.committed.length} files`
             );
         } else {
             Log.error(

--- a/copado-function/app/Commit.js
+++ b/copado-function/app/Commit.js
@@ -812,7 +812,12 @@ class Commit {
                         (item) => !gitDiffArr.includes(item)
                     ),
             };
-            Log.result(result, `Committed ${result.committed.length} items`);
+            Log.result(
+                result,
+                `Committed ${
+                    result.committed.filter((file) => file.endsWith('.json')).length
+                } items`
+            );
         } else {
             Log.error(
                 'Nothing to commit as all selected components have the same content as already exists in Git. ' +

--- a/copado-function/app/Deploy.js
+++ b/copado-function/app/Deploy.js
@@ -312,7 +312,8 @@ async function run() {
     Log.info('Deploy.js done');
     Log.result(
         gitDiffArr,
-        `Deployed ${gitDiffArr.length} items ` + (verificationText ? ` (${verificationText})` : '')
+        `Deployed ${gitDiffArr.filter((gitDiff) => gitDiff.endsWith('.json')).length} items ` +
+            (verificationText ? ` (${verificationText})` : '')
     );
 
     Copado.uploadToolLogs();

--- a/copado-function/app/Deploy.js
+++ b/copado-function/app/Deploy.js
@@ -312,8 +312,9 @@ async function run() {
     Log.info('Deploy.js done');
     Log.result(
         gitDiffArr,
-        `Deployed ${gitDiffArr.filter((gitDiff) => gitDiff.endsWith('.json')).length} items ` +
-            (verificationText ? ` (${verificationText})` : '')
+        `Deployed ${gitDiffArr.filter((item) => item.endsWith('.json')).length} items with ${
+            gitDiffArr.length
+        } files` + (verificationText ? ` (${verificationText})` : '')
     );
 
     Copado.uploadToolLogs();


### PR DESCRIPTION
# PR details

## What is the purpose of this pull request? (put an "X" next to an item)

- [X] Updated a functionality

## What changes did you make? (Give an overview)

Added a filter to show only the gitDiffArr length of .json files at the result message.
