### PR TITLE
299 bug not getting progressstatus on functions

### DIFF
--- a/force-app/main/default/classes/mcdo_RunCopadoFunctionFromLWC.cls
+++ b/force-app/main/default/classes/mcdo_RunCopadoFunctionFromLWC.cls
@@ -129,4 +129,39 @@ public with sharing class mcdo_RunCopadoFunctionFromLWC {
             throw new AuraHandledException(e.getMessage());
         }
     }
+    
+    /**
+     * This function is getting called from the refreshJobProgress in order to give the most recent data from the respective result record.
+     * @param jobExecutionId the id of the job execution
+     * @return Returns resultId, status, lastModified, stepName, progress and isCompleted.
+     */
+    @AuraEnabled
+    public static jobProgressWrapper getJobProgress(String jobExecutionId) {
+        // get the newest result associated with this job execution
+        copado__Result__c[] results = [SELECT Id, LastModifiedDate,
+        copado__JobStep__r.copado__JobExecution__r.copado__Status__c,
+        copado__JobStep__r.copado__JobExecution__r.copado__ErrorMessage__c,
+        copado__Progress_Status__c,
+        copado__JobStep__r.Name
+        FROM copado__Result__c
+        WHERE copado__JobStep__r.copado__JobExecution__c =
+        :jobExecutionId
+        WITH SECURITY_ENFORCED ORDER BY CreatedDate DESC LIMIT 1];
+
+        JobProgressWrapper response = new JobProgressWrapper();
+        if(!results.isEmpty()) {
+            response.resultId = results[0].Id;
+            response.status = results[0].copado__JobStep__r.copado__JobExecution__r.copado__Status__c;
+            response.lastModified = results[0].LastModifiedDate;
+            response.stepName = results[0].copado__JobStep__r.Name;
+
+            // calculate progress with the Job Execution error message, or the last progress status  
+            response.progress = String.isNotEmpty(results[0].copado__JobStep__r.copado__JobExecution__r.copado__ErrorMessage__c)
+                ?results[0].copado__JobStep__r.copado__JobExecution__r.copado__ErrorMessage__c
+                :results[0].copado__Progress_Status__c;
+            response.isCompleted = (response.status == 'Successful' || response.status == 'Error' || response.status == 'Canceled');
+        }
+        
+        return response;
+    }
 }

--- a/force-app/main/default/classes/mcdo_RunCopadoFunctionFromLWC.cls
+++ b/force-app/main/default/classes/mcdo_RunCopadoFunctionFromLWC.cls
@@ -129,4 +129,40 @@ public with sharing class mcdo_RunCopadoFunctionFromLWC {
             throw new AuraHandledException(e.getMessage());
         }
     }
+
+    public static jobProgressWrapper getJobProgress(String jobExecutionId)
+    {
+        // get the newest result associated with this job execution
+        copado__Result__c[] results = [SELECT Id, LastModifiedDate,
+            copado__JobStep__r.copado__JobExecution__r.copado__Status__c,
+            copado__JobStep__r.copado__JobExecution__r.copado__ErrorMessage__c,
+            copado__Progress_Status__c,
+            copado__JobStep__r.Name
+            FROM copado__Result__c
+            WHERE copado__JobStep__r.copado__JobExecution__c = :jobExecutionId
+            WITH SECURITY_ENFORCED ORDER BY CreatedDate DESC LIMIT 1];
+        JobProgressWrapper response = new JobProgressWrapper();
+        if(!results.isEmpty()) {
+            response.resultId = results[0].Id;
+            response.status = results[0].copado__JobStep__r.copado__JobExecution__r.copado__Status__c;
+            response.lastModified = results[0].LastModifiedDate;
+            response.stepName = results[0].copado__JobStep__r.Name;
+            // calculate progress with the Job Execution error message, or the last progress status
+            response.progress =
+                String.isNotEmpty(results[0].copado__JobStep__r.copado__JobExecution__r.copado__ErrorMessage__c)
+                ?results[0].copado__JobStep__r.copado__JobExecution__r.copado__ErrorMessage__c
+                :results[0].copado__Progress_Status__c;
+            response.isCompleted = (response.status == 'Successful' || response.status == 'Error' || response.status == 'Canceled');
+        }
+        return response;
+    }
+    
+    public class JobProgressWrapper {
+        @AuraEnabled public String resultId = '';
+        @AuraEnabled public String status = '';
+        @AuraEnabled public String progress = '';
+        @AuraEnabled public Datetime lastModified = null;
+        @AuraEnabled public String stepName = '';
+        @AuraEnabled public Boolean isCompleted = false;
+    }
 }

--- a/force-app/main/default/classes/mcdo_RunCopadoFunctionFromLWC.cls
+++ b/force-app/main/default/classes/mcdo_RunCopadoFunctionFromLWC.cls
@@ -129,39 +129,4 @@ public with sharing class mcdo_RunCopadoFunctionFromLWC {
             throw new AuraHandledException(e.getMessage());
         }
     }
-    
-    /**
-     * This function is getting called from the refreshJobProgress in order to give the most recent data from the respective result record.
-     * @param jobExecutionId the id of the job execution
-     * @return Returns resultId, status, lastModified, stepName, progress and isCompleted.
-     */
-    @AuraEnabled
-    public static jobProgressWrapper getJobProgress(String jobExecutionId) {
-        // get the newest result associated with this job execution
-        copado__Result__c[] results = [SELECT Id, LastModifiedDate,
-        copado__JobStep__r.copado__JobExecution__r.copado__Status__c,
-        copado__JobStep__r.copado__JobExecution__r.copado__ErrorMessage__c,
-        copado__Progress_Status__c,
-        copado__JobStep__r.Name
-        FROM copado__Result__c
-        WHERE copado__JobStep__r.copado__JobExecution__c =
-        :jobExecutionId
-        WITH SECURITY_ENFORCED ORDER BY CreatedDate DESC LIMIT 1];
-
-        JobProgressWrapper response = new JobProgressWrapper();
-        if(!results.isEmpty()) {
-            response.resultId = results[0].Id;
-            response.status = results[0].copado__JobStep__r.copado__JobExecution__r.copado__Status__c;
-            response.lastModified = results[0].LastModifiedDate;
-            response.stepName = results[0].copado__JobStep__r.Name;
-
-            // calculate progress with the Job Execution error message, or the last progress status  
-            response.progress = String.isNotEmpty(results[0].copado__JobStep__r.copado__JobExecution__r.copado__ErrorMessage__c)
-                ?results[0].copado__JobStep__r.copado__JobExecution__r.copado__ErrorMessage__c
-                :results[0].copado__Progress_Status__c;
-            response.isCompleted = (response.status == 'Successful' || response.status == 'Error' || response.status == 'Canceled');
-        }
-        
-        return response;
-    }
 }

--- a/force-app/main/default/lwc/mcdo_RetrieveTable/mcdo_RetrieveTable.js
+++ b/force-app/main/default/lwc/mcdo_RetrieveTable/mcdo_RetrieveTable.js
@@ -338,11 +338,11 @@ export default class mcdo_RetrieveTable extends LightningElement {
         const progressMessageCallback = async (response) => {
             if (response.data.payload.copado__Progress_Status__c === "Refresh done") {
                 this.unsubscribeThisSubscription(this.getProgressSubscription);
+                this.progressStatus = "Completed!";
             } else {
                 // call an apex function that got the result status
                 getJobProgress({ jobExecutionId: jobExecutionId })
                     .then((result) => {
-                        console.log(JSON.stringify(result));
                         this.progressStatus = result.progress || result.status;
                     })
                     .catch((error) => {
@@ -390,7 +390,7 @@ export default class mcdo_RetrieveTable extends LightningElement {
 
     async unsubscribeThisSubscription(subscription) {
         try {
-            unsubscribeEmp(subscription);
+            unsubscribeEmp(subscription, () => {});
         } catch (err) {
             this.showError(
                 `${err.name}: An error occurred while unsubscribing from Emp API`,

--- a/force-app/main/default/lwc/mcdo_RetrieveTable/mcdo_RetrieveTable.js
+++ b/force-app/main/default/lwc/mcdo_RetrieveTable/mcdo_RetrieveTable.js
@@ -349,7 +349,7 @@ export default class mcdo_RetrieveTable extends LightningElement {
         try {
             let details = await getJobProgress({ jobExecutionId: this.jobExecutionId });
             this.resultId = details.resultId;
-            this.status = details.status;
+            this.progressStatus = details.status;
             this.progress = details.progress;
             this.stepName = details.stepName;
             this.lastModified = details.lastModified;

--- a/force-app/main/default/lwc/mcdo_RetrieveTable/mcdo_RetrieveTable.js
+++ b/force-app/main/default/lwc/mcdo_RetrieveTable/mcdo_RetrieveTable.js
@@ -148,6 +148,9 @@ export default class mcdo_RetrieveTable extends LightningElement {
     sortDirection = "desc";
     sortedBy = "ld";
 
+    // Stages
+    // stages = ["Retrieve.js started", ""];
+
     // Search Functionality related variables
     keyword;
     allSelectedRows = [];
@@ -164,7 +167,6 @@ export default class mcdo_RetrieveTable extends LightningElement {
 
     _subscribeToMessageService() {
         subscribeMessageService(this._context, COMMIT_PAGE_COMMUNICATION_CHANNEL, (message) => {
-            console.log(`message: ${message}`);
             this._handleCommitPageCommunicationMessage(message);
         });
     }
@@ -335,13 +337,13 @@ export default class mcdo_RetrieveTable extends LightningElement {
      */
     async subscribeToCompletionEvent(jobExecutionId) {
         const messageCallback = async (response) => {
-            console.log(
-                `response.data.payload.copado__Topic_Uri__c: ${response.data.payload.copado__Topic_Uri__c}`
-            );
-            console.log(
-                `response.data.payload.copado__Payload__c: ${response.data.payload.copado__Payload__c}`
-            );
-            console.log(`response.data.payload: ${response.data.payload}`);
+            // console.log(
+            //     `response.data.payload.copado__Topic_Uri__c: ${response.data.payload.copado__Topic_Uri__c}`
+            // );
+            // console.log(
+            //     `response.data.payload.copado__Payload__c: ${response.data.payload.copado__Payload__c}`
+            // );
+            console.log(`response.data.payload: ${JSON.stringify(response.data.payload)}`);
             if (
                 response.data.payload.copado__Topic_Uri__c ===
                 `/execution-completed/${jobExecutionId}`
@@ -366,9 +368,7 @@ export default class mcdo_RetrieveTable extends LightningElement {
         };
 
         try {
-            console.log(`this.channelName: ${this.channelName}`);
             this.empSubscription = await subscribeEmp(this.channelName, -1, messageCallback);
-            console.log(`this.empSubscription: ${JSON.stringify(this.empSubscription)}`);
         } catch (err) {
             this.showError(
                 `${err.name}: An error occurred while subscribing to Emp API`,

--- a/force-app/main/default/lwc/mcdo_RetrieveTable/mcdo_RetrieveTable.js
+++ b/force-app/main/default/lwc/mcdo_RetrieveTable/mcdo_RetrieveTable.js
@@ -23,7 +23,7 @@ import {
 } from "lightning/empApi";
 
 // Apex Methods for retrieving and committing metadata (And Communication with the Copado Package)
-import ExecuteRetrieveFromCopado from "@salesforce/apex/mcdo_RunCopadoFunctionFromLWC.executeRetrieve";
+import executeRetrieve from "@salesforce/apex/mcdo_RunCopadoFunctionFromLWC.executeRetrieve";
 import getMetadataFromEnvironment from "@salesforce/apex/mcdo_RunCopadoFunctionFromLWC.getMetadataFromEnvironment";
 
 // Apex functions to retrieve Recorddata from LWC
@@ -307,9 +307,18 @@ export default class mcdo_RetrieveTable extends LightningElement {
         this.loadingState(true, "Starting Retrieve");
 
         try {
-            const jobExecutionId = await ExecuteRetrieveFromCopado({
+            const jobExecutionId = await executeRetrieve({
                 userStoryId: this.userStoryId
             });
+
+            console.log(`jobExecutionId: ${jobExecutionId} - daniel`);
+
+            // this.resultId = details.resultId;
+            // this.status = details.status;
+            // this.progress = details.progress;
+            // this.stepName = details.stepName;
+            // this.lastModified = details.lastModified;
+            // this.jobIsRunning = !details.isCompleted;
             // TODO get result ID from Job step related to job execution
             //! has to be last result created for that job step if there are multiple
             this.subscribeToCompletionEvent(jobExecutionId);
@@ -325,6 +334,7 @@ export default class mcdo_RetrieveTable extends LightningElement {
                 this.selectedRows = this.selectedRows.map(({ id }) => id);
             }
         }
+        console.log("ended - daniel");
     }
 
     /**
@@ -349,6 +359,8 @@ export default class mcdo_RetrieveTable extends LightningElement {
                     // show progress on screen; try-catch is needed because copado__Payload__c sometimes contains bad JSON
                     const stepStatus = JSON.parse(response.data.payload.copado__Payload__c);
                     this.progressStatus = stepStatus.data.progressStatus || this.progressStatus;
+                    console.log("its not completed yet - daniel");
+                    console.log(`stepStatus: ${JSON.stringify(stepStatus)} - daniel`);
                 } catch {
                     // ignore
                 }

--- a/force-app/main/default/lwc/mcdo_RetrieveTable/mcdo_RetrieveTable.js
+++ b/force-app/main/default/lwc/mcdo_RetrieveTable/mcdo_RetrieveTable.js
@@ -163,9 +163,10 @@ export default class mcdo_RetrieveTable extends LightningElement {
     channelName = "/event/copado__Event__e";
 
     _subscribeToMessageService() {
-        subscribeMessageService(this._context, COMMIT_PAGE_COMMUNICATION_CHANNEL, (message) =>
-            this._handleCommitPageCommunicationMessage(message)
-        );
+        subscribeMessageService(this._context, COMMIT_PAGE_COMMUNICATION_CHANNEL, (message) => {
+            console.log(`message: ${message}`);
+            this._handleCommitPageCommunicationMessage(message);
+        });
     }
 
     /**
@@ -334,12 +335,20 @@ export default class mcdo_RetrieveTable extends LightningElement {
      */
     async subscribeToCompletionEvent(jobExecutionId) {
         const messageCallback = async (response) => {
+            console.log(
+                `response.data.payload.copado__Topic_Uri__c: ${response.data.payload.copado__Topic_Uri__c}`
+            );
+            console.log(
+                `response.data.payload.copado__Payload__c: ${response.data.payload.copado__Payload__c}`
+            );
+            console.log(`response.data.payload: ${response.data.payload}`);
             if (
                 response.data.payload.copado__Topic_Uri__c ===
                 `/execution-completed/${jobExecutionId}`
             ) {
                 // retrieve is done: refresh table with new data
                 this.updateMetadataGrid(response, jobExecutionId);
+                console.log("its completed");
             } else if (
                 response.data.payload.copado__Topic_Uri__c.startsWith(
                     "/events/copado/v1/step-monitor/" // + resultId
@@ -351,12 +360,15 @@ export default class mcdo_RetrieveTable extends LightningElement {
                     this.progressStatus = stepStatus.data.progressStatus || this.progressStatus;
                 } catch {
                     // ignore
+                    console.log("its not yet completed");
                 }
             }
         };
 
         try {
+            console.log(`this.channelName: ${this.channelName}`);
             this.empSubscription = await subscribeEmp(this.channelName, -1, messageCallback);
+            console.log(`this.empSubscription: ${JSON.stringify(this.empSubscription)}`);
         } catch (err) {
             this.showError(
                 `${err.name}: An error occurred while subscribing to Emp API`,

--- a/force-app/main/default/lwc/mcdo_RetrieveTable/mcdo_RetrieveTable.js
+++ b/force-app/main/default/lwc/mcdo_RetrieveTable/mcdo_RetrieveTable.js
@@ -23,8 +23,7 @@ import {
 } from "lightning/empApi";
 
 // Apex Methods for retrieving and committing metadata (And Communication with the Copado Package)
-import executeRetrieve from "@salesforce/apex/mcdo_RunCopadoFunctionFromLWC.executeRetrieve";
-import getJobProgress from "@salesforce/apex/mcdo_RunCopadoFunctionFromLWC.getJobProgress";
+import ExecuteRetrieveFromCopado from "@salesforce/apex/mcdo_RunCopadoFunctionFromLWC.executeRetrieve";
 import getMetadataFromEnvironment from "@salesforce/apex/mcdo_RunCopadoFunctionFromLWC.getMetadataFromEnvironment";
 
 // Apex functions to retrieve Recorddata from LWC
@@ -306,26 +305,11 @@ export default class mcdo_RetrieveTable extends LightningElement {
      */
     async retrieve() {
         this.loadingState(true, "Starting Retrieve");
-        // update the UI immediately, clearing any previous values
-        this.jobExecutionId = null;
-        this.progressStatus = "Requesting";
-        this.lastModified = new Date();
-        this.progress = "";
-        this.jobIsRunning = true;
-        this.showProgress = true;
 
         try {
-            const jobExecutionId = await executeRetrieve({
+            const jobExecutionId = await ExecuteRetrieveFromCopado({
                 userStoryId: this.userStoryId
             });
-
-            console.log(`jobExecutionId: ${jobExecutionId} - daniel`);
-
-            // Start the polling process to track the job via UI
-            this.jobExecutionId = jobExecutionId;
-            this.jobExecutionIdUrl = "/" + jobExecutionId;
-            this.poll(() => this.refreshJobProgress());
-
             // TODO get result ID from Job step related to job execution
             //! has to be last result created for that job step if there are multiple
             this.subscribeToCompletionEvent(jobExecutionId);
@@ -340,62 +324,6 @@ export default class mcdo_RetrieveTable extends LightningElement {
             if (this.selectedRows.length > 0) {
                 this.selectedRows = this.selectedRows.map(({ id }) => id);
             }
-        }
-        console.log("ended - daniel");
-    }
-
-    // read the job progress and assign the UI properties
-    async refreshJobProgress() {
-        try {
-            let details = await getJobProgress({ jobExecutionId: this.jobExecutionId });
-            this.resultId = details.resultId;
-            this.progressStatus = details.status;
-            this.progress = details.progress;
-            this.stepName = details.stepName;
-            this.lastModified = details.lastModified;
-            this.jobIsRunning = !details.isCompleted;
-        } catch (error) {
-            console.error(
-                "There was an error trying to read the progress of the job. Will retry.",
-                error
-            );
-        }
-    }
-
-    // LWC METHODS
-    disconnectedCallback() {
-        this.stopPoll(); // ensure we disconnect the polling.
-    }
-
-    // call functionCall and if it returns true, call again every 5s for the first 5m, 10s after 5m, 30s after 30m, 60s after 1h
-    poll(functionCall, pollStartTime) {
-        if (!pollStartTime) {
-            this.pollStop = false;
-            pollStartTime = new Date().getTime();
-        }
-        if (!functionCall.apply() || this.pollStop) {
-            return this.stopPoll();
-        }
-        let elapsedMs = new Date().getTime() - pollStartTime;
-        let intervalMs =
-            elapsedMs > 3600000
-                ? 60000
-                : elapsedMs > 1800000
-                ? 30000
-                : elapsedMs > 300000
-                ? 10000
-                : 5000;
-        this.pollProcessId = window.setTimeout(
-            () => this.poll(functionCall, pollStartTime),
-            intervalMs
-        );
-    }
-    // use this method to stop the polling, e.g. from the UI or when disconnectedCallback occurs
-    stopPoll() {
-        this.pollStop = true;
-        if (this.pollProcessId) {
-            window.clearTimeout(this.pollProcessId);
-            this.pollProcessId = null;
         }
     }
 
@@ -421,8 +349,6 @@ export default class mcdo_RetrieveTable extends LightningElement {
                     // show progress on screen; try-catch is needed because copado__Payload__c sometimes contains bad JSON
                     const stepStatus = JSON.parse(response.data.payload.copado__Payload__c);
                     this.progressStatus = stepStatus.data.progressStatus || this.progressStatus;
-                    console.log("its not completed yet - daniel");
-                    console.log(`stepStatus: ${JSON.stringify(stepStatus)} - daniel`);
                 } catch {
                     // ignore
                 }


### PR DESCRIPTION
# PR details

## What is the purpose of this pull request? (put an "X" next to an item)

- [X] Bug fix
- Before, we were not able to get the loading spinner updated with the refresh's progress status at the retrieve function, this PR fixes that bug.

## What changes did you make? (Give an overview)

- Created a new apex method to get the progress status of a specific result
- In the LWC used the event that was already there to know when to refresh the table, and added a new subscription to the MC_RESULT event to get the progress status of a specified job execution (using the new apex method)
- Fixed the unsubscribed bug (before we were getting an error in the developer console every time that the script tried to unsubscribe because it needed 2 parameters, and we were providing only one. 

> Unsubscribe documentation:
> https://developer.salesforce.com/docs/component-library/bundle/lightning-emp-api/documentation
